### PR TITLE
Fix missing config.yaml for Weasel (Windows RIME)

### DIFF
--- a/weasel.custom.yaml
+++ b/weasel.custom.yaml
@@ -1,0 +1,6 @@
+# weasel.custom.yaml
+patch:
+  style/font_face: "JyutcitziWithSourceHanSansHC"
+  style/font_point: 22
+  style/label_font_face: "JyutcitziWithSourceHanSansHC"
+  style/label_font_point: 22 #pre-selected column number font size


### PR DESCRIPTION
Closes #3 

## Solution

Add `weasel.custom.yaml`.